### PR TITLE
Fixed issues with applications having blank spaces in their name

### DIFF
--- a/module/bin/ipa.sh
+++ b/module/bin/ipa.sh
@@ -2,7 +2,7 @@
 
 source "$STAGE"
 
-function copy { eval "rsync -a $* $_THEOS_RSYNC_EXCLUDE_COMMANDLINE"; }
+function copy { eval "rsync -s -a \"$1\" \"$2\" $_THEOS_RSYNC_EXCLUDE_COMMANDLINE"; }
 
 if [[ -d $RESOURCES_DIR ]]; then
 	log 2 "Copying resources"


### PR DESCRIPTION
This pull request aims to solve issue #31 

As your MacOS version might be using a different rsync version, it might be required to update it using the following command: 

> brew install homebrew/dupes/rsync