### PR TITLE
Change BundleID and DisplayName on an iOS device

### DIFF
--- a/module/bin/readPlist.sh
+++ b/module/bin/readPlist.sh
@@ -1,0 +1,29 @@
+
+__currentOS=$(sw_vers | awk '/ProductName:/ {print$2}')
+__readID=$1;
+__file=$2;
+__result="";
+__convertToXML(){
+  plutil -convert xml1 "$__file" | sed 's/Converted .*//' | sed -n ':a;N;$!ba;s/\n//g';
+}
+
+__convertToPlist(){
+  plutil -convert binary1 "$__file" | sed 's/Converted .*//' | sed -n ':a;N;$!ba;s/\n//g';
+}
+
+__readFromPlist(){
+  if [[ $__currentOS == "Mac" ]]; then
+      local data=$(/usr/libexec/PlistBuddy -c "Print :$__readID" "$__file")
+      __result="$data"
+  else
+      local data=`awk "/$__readID/ {getline;print$1}" "$__file" | sed  -E "s/[[:space:]]+//" | sed -n '/^$/!{s/<[^>]*>//g;p;}'`;
+      __result="$data";
+  fi
+}
+
+__convertToXML;
+__readFromPlist;
+__convertToPlist;
+
+# result=$(__readFromPlist)
+echo "$__result";

--- a/module/bin/stage.sh
+++ b/module/bin/stage.sh
@@ -28,4 +28,4 @@ if [[ ! -d $appdir ]]; then
 fi
 
 info_plist="$appdir/Info.plist"
-app_bundle_id=$(/usr/libexec/PlistBuddy -c "Print :CFBundleIdentifier" "$info_plist")
+app_bundle_id=$(/bin/bash $THEOS/mod/jailed/bin/readPlist.sh CFBundleIdentifier "$info_plist")

--- a/module/bin/writePlist.sh
+++ b/module/bin/writePlist.sh
@@ -1,0 +1,36 @@
+
+__currentOS=$(sw_vers | awk '/ProductName:/ {print$2}')
+__CFid=$1
+__newID=$2;
+__file=$3;
+
+__convertToXML(){
+  plutil -convert xml1 "$__file" | sed 's/Converted .*//' | sed -n ':a;N;$!ba;s/\n//g';
+}
+
+__convertToPlist(){
+  plutil -convert binary1 "$__file" | sed 's/Converted .*//' | sed -n ':a;N;$!ba;s/\n//g';
+}
+
+__changeBundleID(){
+  if [[ $__currentOS == "Mac" ]]; then
+    /usr/libexec/PlistBuddy -c "Add :"$__CFid" string" "$__file"
+    /usr/libexec/PlistBuddy -c "Set :"$__CFid" $__newID" "$__file"
+    # plutil -replace $__CFid -string "$__newID" "$__file"
+  elif [[ $__currentOS == "iPhone" ]]; then
+    plutil -key $__CFid -value "$__newID" "$__file"
+  else
+    local old=$(awk "/$__CFid/ {getline;print$1}" "$__file" | sed -n '/^$/!{s/<[^>]*>//g;p;}');
+    local new=$__newID
+    sed -i '' -e "/$__CFid/,/string/ s/$old/$new/" "$__file"
+fi
+}
+
+if [[ $__currentOS == "Mac" ]] ; then
+  __changeBundleID;
+else
+  __convertToXML;
+  __changeBundleID;
+  __convertToPlist;
+fi
+#


### PR DESCRIPTION
allows to change the Bundle Identifier and App's Display Name on-device. (app injection requires "insert_dylib" from level3tjg's repo (https://level3tjg.xyz/repo/)