### PR TITLE
Proper Fix for Codesign Name

### DIFF
--- a/module/bin/ipa.sh
+++ b/module/bin/ipa.sh
@@ -89,7 +89,7 @@ if [[ $_CODESIGN_IPA = 1 ]]; then
 		codesign_name=$(security find-certificate -c "$DEV_CERT_NAME" login.keychain | grep alis | cut -f4 -d\" | cut -f1 -d\")
 	else
 		# http://maniak-dobrii.com/extracting-stuff-from-provisioning-profile/
-		codesign_name=$(/usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:0" "$PROFILE_FILE" | openssl x509 -noout -inform DER -subject | sed -E 's/^.*CN=([^\/]*)\/.*$/\1/')
+		codesign_name=$(/usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:0" "$PROFILE_FILE" | openssl x509 -noout -inform DER -subject | sed -E 's/^.*CN\s*=\s*([^\/]*)\/.*$/\1/')
 	fi
 	if [[ -z $codesign_name ]]; then
 		error "Failed to get codesign name"

--- a/module/bin/ipa.sh
+++ b/module/bin/ipa.sh
@@ -89,7 +89,7 @@ if [[ $_CODESIGN_IPA = 1 ]]; then
 		codesign_name=$(security find-certificate -c "$DEV_CERT_NAME" login.keychain | grep alis | cut -f4 -d\" | cut -f1 -d\")
 	else
 		# http://maniak-dobrii.com/extracting-stuff-from-provisioning-profile/
-		codesign_name=$(/usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:0" "$PROFILE_FILE" | openssl x509 -noout -inform DER -subject | sed -E 's/^.*CN\s*=\s*([^\/]*)\/.*$/\1/')
+		codesign_name=$(/usr/libexec/PlistBuddy -c "Print :DeveloperCertificates:0" "$PROFILE_FILE" | openssl x509 -noout -inform DER -subject | sed -E 's/.*CN[[:space:]]*=[[:space:]]*([^,]+).*/\1/')
 	fi
 	if [[ -z $codesign_name ]]; then
 		error "Failed to get codesign name"


### PR DESCRIPTION
Tested this time in both scenarios of spaces / no spaces around the '=' in the OpenSSL output.