### PR TITLE
Dynamically determine Logos generator fallback

### DIFF
--- a/module/common.mk
+++ b/module/common.mk
@@ -48,7 +48,8 @@ export USE_OVERLAY = $(call __theos_bool,$($(TWEAK_NAME)_USE_OVERLAY))
 export OVERLAY ?= $(THEOS_JAILED_LIB)/Overlay.dylib
 
 # CydiaSubstrate
-export GENERATOR = $(or $($(TWEAK_NAME)_LOGOS_DEFAULT_GENERATOR),$(LOGOS_DEFAULT_GENERATOR),$(_THEOS_TARGET_LOGOS_DEFAULT_GENERATOR),MobileSubstrate)
+_NEEDS_LOGOS = $(if $(shell find $(PWD) -name "*.theos*" -prune -o -type f -name "*.x*" -print),$(_THEOS_TRUE),$(_THEOS_FALSE))
+export GENERATOR = $(or $($(TWEAK_NAME)_LOGOS_DEFAULT_GENERATOR),$(LOGOS_DEFAULT_GENERATOR),$(_THEOS_TARGET_LOGOS_DEFAULT_GENERATOR),$(if $(_NEEDS_LOGOS),MobileSubstrate,internal))
 export SUBSTRATE ?= $(THEOS_JAILED_LIB)/CydiaSubstrate.framework
 export STUB_SUBSTRATE_INSTALL_PATH = /Library/Frameworks/CydiaSubstrate.framework/CydiaSubstrate
 export SUBSTRATE_INSTALL_PATH = @rpath/CydiaSubstrate.framework/CydiaSubstrate


### PR DESCRIPTION
Previously, the generator defaulting to substrate would result in substrate being linked due to [Theos' generator check](https://github.com/theos/theos/blob/65b549c4a97c3c9f51bd912395fd244b8aadc741/makefiles/instance/tweak.mk#L15-L19). This is problematic for users using non-substrate hooking techniques, such as fishhook. Common.mk now checks for the presence of Logos files and adjusts the generator fallback accordingly -- substrate if `.x*` is present else internal. 

Note: this will become unnecessary if/when [theos/logos#110](https://github.com/theos/logos/pull/110) is merged, which will allow us to remove Theos' handling of injection lib linking.   